### PR TITLE
Fix: text/event-stream;charset=utf-8 content-type

### DIFF
--- a/src/EventSource.js
+++ b/src/EventSource.js
@@ -375,7 +375,7 @@ class EventSource extends (EventTarget(...EVENT_SOURCE_EVENTS): any) {
 
     if (
       responseHeaders &&
-      responseHeaders['content-type'] !== 'text/event-stream'
+      responseHeaders['content-type'].split(";").shift() !== 'text/event-stream'
     ) {
       this.dispatchEvent({
         type: 'error',


### PR DESCRIPTION
Some times content-type can be like text/event-stream;charset=utf-8 and raises "unsupported MIME type in response ... " error